### PR TITLE
virtual-desktops-only-on-primary: use workspace.screens for primary d…

### DIFF
--- a/virtual-desktops-only-on-primary/contents/code/main.js
+++ b/virtual-desktops-only-on-primary/contents/code/main.js
@@ -2,7 +2,6 @@ function log(msg) {
      //print("VDOnPrimary: " + msg);
 }
 
-var primaryScreen = workspace.activeScreen;
 
 function bind(window) {
     window.previousOutput = window.output;
@@ -18,7 +17,7 @@ function update(window) {
         return;
     }
 
-    //var primaryScreen = 0;
+    const primaryScreen = workspace.screens[0];
     var currentScreen = window.output;
     var previousScreen = window.previousOutput;
     window.previousOutput = currentScreen;


### PR DESCRIPTION
As it is now, the script uses `workspace.activeScreen` which is the screen that the cursor is located on. On startup with multiple screens that would indeed most likely be the primary screen, however after a display change (eg. plugging a different monitor or changing priorities in the display settings), the script would not update to accomodate this change.

`workspace.screens` is an array of screens arranged in the priority list as found in the display settings options, hence the first one is the "primary screen".